### PR TITLE
(minor documentation typo) Hfnhf patch 01

### DIFF
--- a/docs/data_collection_feedback.rst
+++ b/docs/data_collection_feedback.rst
@@ -6,7 +6,7 @@ finetuned language models:
 
 .. code:: python
 
-  import pykpi as pk
+  import pykoi as pk
 
   # assume you have some model, endpoint, or api
   model = your_model
@@ -41,7 +41,7 @@ the machine that hosted the UI. The data can be easily explored or exported ther
 
 .. code:: python
 
-  import pykpi as pk
+  import pykoi as pk
 
   # assume you have some model, endpoint, or api
   model = your_model

--- a/docs/data_labeling_annotation.rst
+++ b/docs/data_labeling_annotation.rst
@@ -14,7 +14,7 @@ predefined summaries, for example, ...
 
 .. code:: python
 
-  import pykpi as pk
+  import pykoi as pk
 
   # assume you have some model, endpoint, or api
   model = your_model
@@ -36,7 +36,7 @@ predefined summaries, for example, ...
 
 .. code:: python
 
-  import pykpi as pk
+  import pykoi as pk
 
   # assume you have some model, endpoint, or api
   model = your_model
@@ -58,7 +58,7 @@ predefined summaries, for example, ...
 
 .. code:: python
 
-  import pykpi as pk
+  import pykoi as pk
 
   # assume you have some model, endpoint, or api
   model = your_model


### PR DESCRIPTION
appears to be a minor documentation typo: pykpi , changed to pykoi