### PR TITLE
Retrieval QA Demo Small Fixes

### DIFF
--- a/example/retrieval_qa/retrieval_qa_huggingface_demo.py
+++ b/example/retrieval_qa/retrieval_qa_huggingface_demo.py
@@ -16,6 +16,12 @@ from dotenv import load_dotenv
 # Load environment variables from .env file
 load_dotenv()
 
+## Set the RETRIEVAL_MODEL, pykoi supports most of the open-source LLMs, e.g.
+        # "HuggingFaceH4/zephyr-7b-beta"
+        # "meta-llama/Llama-2-7b-chat-hf"
+        # "mistralai/Mistral-7B-v0.1"
+        # "databricks/dolly-v2-3b" 
+        
 RETRIEVAL_MODEL = os.getenv("RETRIEVAL_MODEL")
 
 

--- a/pykoi/retrieval/llm/huggingface.py
+++ b/pykoi/retrieval/llm/huggingface.py
@@ -25,7 +25,7 @@ class HuggingFaceModel(AbsLlm):
                 model_id=kwargs.get("model_name"),
                 task="text-generation",
                 device=torch.cuda.device_count() - 1,
-                pipeline_kwargs={"device_map": "auto"},
+                # pipeline_kwargs={"device_map": "auto"},
                 model_kwargs={
                     "temperature": 0,
                     "max_length": kwargs.get("max_length", 500),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ einops = { version = "0.6.1", optional = true }
 accelerate = { version = "0.21.0", optional = true }
 bitsandbytes = { version = "0.40.2", optional = true }
 
-langchain = { version = "0.0.220", optional = true }
+langchain = { version = "0.0.338", optional = true }
 scikit-learn = { version = "1.3.0", optional = true }
 chromadb = { version = "0.3.26", optional = true }
 pyepsilla = { version = ">=0.1.1", optional = true }


### PR DESCRIPTION


- went through retrieval QA demo using multiple LLMs including 
  - "HuggingFaceH4/zephyr-7b-beta"
  - "meta-llama/Llama-2-7b-chat-hf"
  - "mistralai/Mistral-7B-v0.1"
  - "databricks/dolly-v2-3b" 
  
- upgrade langchain to overcome the bug: 
   > `Inference` initialization failed: The model has been loaded with `accelerate` and therefore cannot be moved to a specific device. Please discard the `device` argument when creating your pipeline object.`
